### PR TITLE
Update Solar Auxilia.cat

### DIFF
--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -498,7 +498,7 @@
                     <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f55a-463f-810b-691a"/>
                   </constraints>
                   <costs>
-                    <cost name="‏‏‎ ‎Transport Usage" typeId="54cb-1324-71d0-d324" value="-4"/>
+                    <cost name="‏‏‎ ‎Transport Usage" typeId="54cb-1324-71d0-d324" value="-2"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Dracosan w/ twin lascannon" hidden="false" type="selectionEntry" id="8c40-5ba9-4dba-e871" targetId="cc26-409d-a289-38e8">


### PR DESCRIPTION
Updated line 501 with -2 transport usage to correctly represent their transport size

Is there any reason the data can't manage -2 as the value here?

It seems perhaps the legality calculations are based upon never allowing you to have more than -3 usage, perhaps for HQ reasons?  

In any case, the correct transport size for Demo cannon Dracosans is 2 stands.